### PR TITLE
add onsiteevent info and hide agenda/speakers for a while

### DIFF
--- a/src/dotnetconfpl/dotnetconfpl/Controllers/HomeController.cs
+++ b/src/dotnetconfpl/dotnetconfpl/Controllers/HomeController.cs
@@ -98,6 +98,11 @@ namespace dotnetconfpl.Controllers
             return View();
         }
 
+        public ActionResult OnSiteEvents()
+        {
+            return View();
+        }
+
         public ActionResult Stream(string id)
         {
             var currentstream = CurrentStream ?? new StreamDocModel {stream = string.Empty, type = string.Empty}; 

--- a/src/dotnetconfpl/dotnetconfpl/Views/Home/OnSiteEvents.cshtml
+++ b/src/dotnetconfpl/dotnetconfpl/Views/Home/OnSiteEvents.cshtml
@@ -1,0 +1,17 @@
+﻿<div class="success" id="about">
+    <div class="container text-center">
+        <div class="row" style="margin-top: 100px">
+            <div class="col-md-6 col-md-offset-3">
+                <h1>Zaangażuj się!</h1>
+                <hr />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <p>dotnetconf.pl to dla community, dlatego w tym roku chcielibyśmy bardziej zaangarzować polskie community do organizacji tego przedsięwziecia!</p>
+                <p>W poprzednich edycjach zauważyliśmy że dużo ludzi spotykało razem aby oglądać dotnetConfpl</p>
+                <p>Więc w tym roku chcemy dać możliwość zorganizowania "oficjalnych" wydarzeń w waszych miastach</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/dotnetconfpl/dotnetconfpl/Views/Shared/_Layout.cshtml
+++ b/src/dotnetconfpl/dotnetconfpl/Views/Shared/_Layout.cshtml
@@ -49,16 +49,19 @@
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right" style="padding: 10px; font-size: 18px">
                     <li>
-                        <a href="@Url.Action("Speakers")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"'>Prelegenci</a>
+                        <a href="@Url.Action("Speakers")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"' class="hidden">Prelegenci</a>
                     </li>
                     <li>
-                        <a href="@Url.Action("Agenda")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"'>Agenda</a>
+                        <a href="@Url.Action("Agenda")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"' class="hidden">Agenda</a>
                     </li>
                     <li>
                         <a href="@Url.Action("Contact")" style="color: #000" onmouseover='this.style.textDecoration = "underline"' onmouseout='this.style.textDecoration = "none"'>Organizatorzy</a>
                     </li>
                     <li>
-                        <a href="@Url.Action("CallForPapers")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"'>Call For Papers</a>
+                        <a href="@Url.Action("CallForPapers")" style="color: #000" onmouseover='this.style.textDecoration = "underline"' onmouseout='this.style.textDecoration = "none"'>Call For Papers</a>
+                    </li>
+                    <li>
+                        <a href="@Url.Action("OnSiteEvents")" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"'>Zaangażuj się!</a>
                     </li>
                     <li style="vertical-align: middle">
                         <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: #000" onmouseover='this.style.textDecoration="underline"' onmouseout='this.style.textDecoration="none"'>Poprzednie edycje <span class="caret"></span></a>

--- a/src/dotnetconfpl/dotnetconfpl/dotnetconfpl.csproj
+++ b/src/dotnetconfpl/dotnetconfpl/dotnetconfpl.csproj
@@ -481,6 +481,7 @@
     <Content Include="Views\Home\Stream.cshtml" />
     <Content Include="Views\Home\CallForPapers.cshtml" />
     <Content Include="Views\Shared\Partials\_MailinglistPartial.cshtml" />
+    <Content Include="Views\Home\OnSiteEvents.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Areas\2013\Models\" />


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1385487/14407144/5a744e46-feb6-11e5-8a9c-ad94776c90f2.png)

Current look of website, top nav has changed added `call for papers` and `zaangażuj sie` links